### PR TITLE
Fixed broken link to the releases README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project currently only supports Windows.
 
 ### Windows
 
-Check out the [releases here](1). You probably want the win64 version.
+Check out the [releases here][releases]. You probably want the win64 version.
 1. Download the .exe file (e.g. `ActionsPerMinuteTracker-win64.exe`)
 2. Run it to start tracking
 3. See your actions per minute in the upper right corner


### PR DESCRIPTION
The actual link in _releases here_ points to a page not found error. I fixed it so that the link actually directs the user to the .exe